### PR TITLE
Add generation of negative data from colab and corresponding unit tests

### DIFF
--- a/smart_news_query_embeddings/preprocessing/generate_negative_data.py
+++ b/smart_news_query_embeddings/preprocessing/generate_negative_data.py
@@ -1,0 +1,56 @@
+import random
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+from smart_news_query_embeddings.preprocessing.specificity_scores import \
+get_spacy_responses
+
+def generate_negatives_from_spacy_responses(token_lists, sentences, labels, ratio=1):
+
+    token_lists = pd.Series(token_lists)
+
+    # Filter out sentences with no named entities outputted by the NER.
+    final_token_lists = token_lists[~token_lists.apply(lambda l: len(l) == 0)]
+
+    # Group sentences by the tokens that appear in the sentence.
+    # Do this manually, since it is possible for sentences to appear
+    # in more than one group.
+    type_indices = dict()
+
+    for i in tqdm(final_token_lists.index):
+        sentence = final_token_lists.loc[i]
+        for token, token_type in sentence:
+            if token_type not in type_indices:
+                type_indices[token_type] = set()
+            type_indices[token_type].add(i)
+
+    # Calculate the relative frequencies of each entity type, and pass these to the function
+    # that randomly samples entity types.
+    keys = list(type_indices.keys())
+    probs = np.array([len(type_indices[k]) for k in keys])
+    probs = probs / probs.sum()
+
+    negatives = []
+    num_negs = int(ratio * len(sentences))
+    pairs = set()
+    print('Generating {} negatives'.format(num_negs))
+    with tqdm(total=num_negs) as pbar:
+        while len(negatives) < num_negs:
+            key = np.random.choice(keys, p=probs)
+            if len(type_indices[key]) < 2:
+                continue
+            i, j = random.sample(type_indices[key], 2)
+            if (i, j) in pairs:
+                continue
+            sec1, sec2 = labels.iloc[i], labels.iloc[j]
+            sent1, sent2 = sentences.iloc[i], sentences.iloc[j]
+            pairs.add((i, j))
+            pairs.add((j, i))
+            if sec1 != sec2:
+                negatives.extend([(sent1, sec2), (sent2, sec1)])
+                pbar.update(2)
+    return pd.DataFrame(negatives[:num_negs], columns=['sentence', 'label'])
+
+def generate_negatives(sentences, labels, ratio=1):
+    _, token_lists = get_spacy_responses(sentences)
+    return generate_negatives_from_spacy_responses(token_lists, sentences, labels, ratio=ratio)

--- a/smart_news_query_embeddings/preprocessing/specificity_scores.py
+++ b/smart_news_query_embeddings/preprocessing/specificity_scores.py
@@ -29,6 +29,8 @@ def get_spacy_responses(sentences):
     from each sentence. This is a key part of the
     specificity score algorithm.
     """
+    N = len(sentences)
+    print('Running NER on {} sentences'.format(N))
 
     token_lists = []
     tokens = []

--- a/smart_news_query_embeddings/tests/test_generate_negative_data.py
+++ b/smart_news_query_embeddings/tests/test_generate_negative_data.py
@@ -47,8 +47,8 @@ class TestGenerateNegativeData(unittest.TestCase):
 		self.assertEqual(negatives.shape[0], 2)
 
 		# the negatives should be ('sentence1', 'label2') and ('sentence2', 'label1')
-		self.assertTrue(negatives[negatives['sentence'] == 'sentence1'].iloc[0]['label'] == 'label2')
-		self.assertTrue(negatives[negatives['sentence'] == 'sentence2'].iloc[0]['label'] == 'label1')
+		self.assertEqual(negatives[negatives['sentence'] == 'sentence1'].iloc[0]['label'], 'label2')
+		self.assertEqual(negatives[negatives['sentence'] == 'sentence2'].iloc[0]['label'], 'label1')
 
 if __name__ == '__main__':
 	unittest.main()

--- a/smart_news_query_embeddings/tests/test_generate_negative_data.py
+++ b/smart_news_query_embeddings/tests/test_generate_negative_data.py
@@ -1,0 +1,54 @@
+import unittest
+import pandas as pd
+from smart_news_query_embeddings.preprocessing.generate_negative_data import \
+generate_negatives, generate_negatives_from_spacy_responses
+from smart_news_query_embeddings.preprocessing.bert_tokenizer import \
+get_filtered_nyt_data_with_scores
+
+class TestGenerateNegativeData(unittest.TestCase):
+
+	DATA_PATH = 'data/nyt_articles_with_normalized_scores.pkl'
+
+	def test_generate_negatives(self):
+
+		"""
+		Make sure that we get as many negatives as we're expecting.
+		"""
+
+		df = get_filtered_nyt_data_with_scores(self.DATA_PATH).sample(100)
+		RATIOS = [0.25, 0.5, 1, 2, 5]
+		for ratio in RATIOS:
+			negatives = generate_negatives(df['fixed_abstract'], df['section'], ratio=ratio)
+			self.assertEqual(negatives.shape[0], int(ratio * len(df)))
+
+	def test_generate_negatives_from_spacy_responses(self):
+
+		"""
+		Test that the algorithm generates negatives from sentences with different labels but containing
+		the same token types.
+		"""
+
+		token_lists = pd.Series([
+			[['token1', 'type1']],
+			[['token5', 'type1']]
+		])
+
+		sentences = pd.Series([
+			'sentence1',
+			'sentence2',
+		])
+
+		labels = pd.Series([
+			'label1',
+			'label2',
+		])
+		ratio = 1
+		negatives = generate_negatives_from_spacy_responses(token_lists, sentences, labels, ratio=ratio)
+		self.assertEqual(negatives.shape[0], 2)
+
+		# the negatives should be ('sentence1', 'label2') and ('sentence2', 'label1')
+		self.assertTrue(negatives[negatives['sentence'] == 'sentence1'].iloc[0]['label'] == 'label2')
+		self.assertTrue(negatives[negatives['sentence'] == 'sentence2'].iloc[0]['label'] == 'label1')
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
Adapted from the Colab notebook created to generate negative examples for training the two-tower model.